### PR TITLE
Fix error running dashboard workflow

### DIFF
--- a/.github/workflows/update_dashboard.yml
+++ b/.github/workflows/update_dashboard.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Commit and push if changed
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"


### PR DESCRIPTION
Fixes #9

Update the `GITHUB_TOKEN` in `.github/workflows/update_dashboard.yml` to use the correct secret.

* Change the `GITHUB_TOKEN` environment variable to use `${{ secrets.GITHUB_TOKEN }}` instead of `${{ secrets.PAT_TOKEN }}`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/UCT-datastewardship/UCT-datastewardship.github.io/pull/10?shareId=d38216cd-b427-4c38-b673-9b47bd0f6e49).